### PR TITLE
use all data instead of data from store to compute total locked usd

### DIFF
--- a/src/stores/Tokens.ts
+++ b/src/stores/Tokens.ts
@@ -20,7 +20,7 @@ export class Tokens extends ListStoreConstructor<ITokenInfo> {
   @observable selectedNetwork: NETWORK_TYPE;
 
   @computed get totalLockedUSD() {
-    return this.data
+    return this.allData
       .filter(a =>
         this.selectedNetwork ? a.network === this.selectedNetwork : true,
       )


### PR DESCRIPTION
When sorting the assets table the computed total locked usd changes due to using the paged data witch has a limit of 100 assets and the bridge has more so the value changes. Using allData fixes this.