### PR TITLE
add nft display

### DIFF
--- a/src/pages/Exchange/Details.tsx
+++ b/src/pages/Exchange/Details.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box } from 'grommet';
+import { Box, Image } from 'grommet';
 import { observer } from 'mobx-react-lite';
 import { Icon, Text } from 'components/Base';
 import { useStores } from 'stores';
@@ -170,6 +170,27 @@ export const Details = observer<{ showTotal?: boolean; children?: any }>(
       }
     };
 
+    const getImage = () => {
+      if (exchange.transaction.nftImageUrl !== '') {
+        return (
+          <Box margin={{bottom: "20px"}} align="center">
+            <Box width="small" direction="row" margin={{bottom: "5px"}}>
+              <Image
+                fit="cover"
+                src={exchange.transaction.nftImageUrl}
+              />
+            </Box>
+            <Box direction="row">
+              <Text size="small" bold={true}>
+                {exchange.transaction.nftName}
+              </Text>
+            </Box>
+          </Box>
+        );
+      }
+      return ""
+    };
+
     return (
       <Box direction="column">
         <AssetRow
@@ -183,6 +204,8 @@ export const Details = observer<{ showTotal?: boolean; children?: any }>(
           address={true}
         />
         {getAmount()}
+
+        {getImage()}
 
         {/*{exchange.mode === EXCHANGE_MODE.ONE_TO_ETH ? (*/}
         {/*  <AssetRow label="Deposit amount" value="">*/}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,7 +2,7 @@ import {
   ACTION_TYPE,
   IOperation,
   ITokenInfo,
-  NETWORK_TYPE, OpenSeaValideResponse,
+  NETWORK_TYPE, OpenSeaSingleAssetResponse, OpenSeaValideResponse,
 } from '../stores/interfaces';
 import * as agent from 'superagent';
 import * as _ from 'lodash';
@@ -367,6 +367,18 @@ export const hasOpenSeaValid = async (erc20Address: string): Promise<OpenSeaVali
   try {
     const res = await agent.get<OpenSeaValideResponse>(
       `https://api.opensea.io/api/v1/asset_contract/${erc20Address}?format=json`,
+    );
+
+    return res.body;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const getOpenSeaSingleAsset = async (assetAddress: string, assetId: string): Promise<OpenSeaSingleAssetResponse | null> => {
+  try {
+    const res = await agent.get<OpenSeaSingleAssetResponse>(
+      `https://api.opensea.io/api/v1/asset/${assetAddress}/${assetId}/?format=json`,
     );
 
     return res.body;

--- a/src/stores/interfaces.ts
+++ b/src/stores/interfaces.ts
@@ -182,3 +182,11 @@ export interface OpenSeaValideResponse {
   },
   address: string,
 }
+
+export interface OpenSeaSingleAssetResponse {
+  name: string,
+  image_preview_url: string,
+  collection: {
+    name: string,
+  },
+}


### PR DESCRIPTION
we can put the contract address and token id, but it would be better to show a preview of the NFT before I can confirm the bridge transaction to avoid issues. Otherwise, if we had a typo, I may end up paying gasfee for a wrong transaction.

so. we add the function for displaying the image and name of NFT when we confirm the transfer.

![image](https://user-images.githubusercontent.com/8352895/142729401-55882eb2-3935-40f6-8ddc-03542c461ebb.png)
